### PR TITLE
Add geoips_plugin_example to git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Install geoips_template_plugin package
     # Assuming you followed the fully supported installation,
     # using $GEOIPS_PACKAGES_DIR and $GEOIPS_CONFIG_FILE:
     source $GEOIPS_CONFIG_FILE
-    git clone -b $GEOIPS_ACTIVE_BRANCH $GEOIPS_REPO_URL $GEOIPS_PACKAGES_DIR/geoips_plugin_example
+    git clone -b $GEOIPS_ACTIVE_BRANCH $GEOIPS_REPO_URL/geoips_plugin_example $GEOIPS_PACKAGES_DIR/geoips_plugin_example
     pip install -e $GEOIPS_PACKAGES_DIR/geoips_plugin_example
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Install geoips_template_plugin package
     # Assuming you followed the fully supported installation,
     # using $GEOIPS_PACKAGES_DIR and $GEOIPS_CONFIG_FILE:
     source $GEOIPS_CONFIG_FILE
-    git clone -b $GEOIPS_ACTIVE_BRANCH $GEOIPS_REPO_URL/geoips_plugin_example $GEOIPS_PACKAGES_DIR/geoips_plugin_example
+    git clone https://github.com/NRLMMD-GEOIPS/geoips_plugin_example $GEOIPS_PACKAGES_DIR/geoips_plugin_example
     pip install -e $GEOIPS_PACKAGES_DIR/geoips_plugin_example
 ```
 


### PR DESCRIPTION
Typo in installation steps included only $GEOIPS_REPO_URL - needs to include geoips_plugin_example. NRLMMD-GEOIPS/geoips_plugin_example#2

# Output
```
(geoips_conda)     git clone -b $GEOIPS_ACTIVE_BRANCH $GEOIPS_REPO_URL/geoips_plugin_example $GEOIPS_PACKAGES_DIR/geoips_plugin_example
Cloning into '$HOME/geoproc/geoips_packages/geoips_plugin_example'...
remote: Enumerating objects: 95, done.
remote: Counting objects: 100% (95/95), done.
remote: Compressing objects: 100% (62/62), done.
remote: Total 95 (delta 26), reused 83 (delta 18), pack-reused 0
Unpacking objects: 100% (95/95), done.
```