### PR TITLE
updated geoips_plugin_package to reflect new changes made to products and sectors

### DIFF
--- a/geoips_plugin_example/plugins/modules/filename_formatters/test_fname.py
+++ b/geoips_plugin_example/plugins/modules/filename_formatters/test_fname.py
@@ -61,12 +61,12 @@ def call(
         extra=extra,
         product_dir=product_dir,
         source_dir=source_dir,
-        continent=area_def.sector_info["continent"],
-        country=area_def.sector_info["country"],
-        area=area_def.sector_info["area"],
-        subarea=area_def.sector_info["subarea"],
-        state=area_def.sector_info["state"],
-        city=area_def.sector_info["city"],
+        continent=area_def.sector_info["region"]["continent"],
+        country=area_def.sector_info["region"]["country"],
+        area=area_def.sector_info["region"]["area"],
+        subarea=area_def.sector_info["region"]["subarea"],
+        state=area_def.sector_info["region"]["state"],
+        city=area_def.sector_info["region"]["city"],
     )
     return web_fname
 

--- a/geoips_plugin_example/plugins/yaml/products/abi.yaml
+++ b/geoips_plugin_example/plugins/yaml/products/abi.yaml
@@ -5,7 +5,7 @@ docstring: The abi products configuration, which produces an Infrared test produ
 spec:
   products:
     - name: Infrared-Test
-      source_name: abi
+      source_names: [abi]
       docstring: Infrared test product
       product_defaults: Infrared-Test
       spec:


### PR DESCRIPTION
# Reviewer Checklist

PR author: Please ensure you meet all of the below requirements, and check boxes appropriately.

Reviewers: Please confirm all required testing/documentation has been completed prior to approving.

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
  * [ ] None required (explain if checked, delete line if not checked)
* [ ] Required ***unit tests*** added and pass for new/modified functionality
  * [x] None required (explain if checked, delete line if not checked)
* [ ] Required ***integration tests*** added and pass for new/modified functionality
  * [x] None required. (explain if checked, delete line if not checked)
* [ ] Required ***documentation*** added for new/modified functionality
  * [x] None required (explain if checked, delete line if not checked)
* [ ] Required ***release notes*** added for new/modified functionality
  * [ ] None required. (explain if checked, delete line if not checked)

https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
None. This was a quick fix, only a couple of lines changed minimally.

# Summary
This package was out of date compared to new changes made to geoips interfaces. Specifically, products (source_names now), and sectors, which have added a sublevel 'region' to their metadata. This is now fixed.

# Output

(geoips) [evrose54@winter scripts]$ ./abi_aws.sh 
27_144454 run_procflow.py:49   INTERACTIVE: 


Starting single_source procflow...


27_144454 run_procflow.py:64   INTERACTIVE: 


Running on filenames: ['/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C02_G16_s20202621950205_e20202621959513_c20202621959546.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C03_G16_s20202621950205_e20202621959513_c20202621959570.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C04_G16_s20202621950205_e20202621959513_c20202621959534.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C05_G16_s20202621950205_e20202621959513_c20202621959562.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C06_G16_s20202621950205_e20202621959518_c20202621959556.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C07_G16_s20202621950205_e20202621959524_c20202621959577.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C08_G16_s20202621950205_e20202621959513_c20202621959574.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C09_G16_s20202621950205_e20202621959518_c20202621959588.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C10_G16_s20202621950205_e20202621959524_c20202621959578.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C11_G16_s20202621950205_e20202621959513_c20202621959583.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C12_G16_s20202621950205_e20202621959518_c20202621959574.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C13_G16_s20202621950205_e20202621959525_c20202622000005.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C14_G16_s20202621950205_e20202621959513_c20202622000009.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C15_G16_s20202621950205_e20202621959518_c20202621959594.nc', '/home/evrose54/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C16_G16_s20202621950205_e20202621959524_c20202622000001.nc']


27_144454 single_source.py:1407 INTERACTIVE: Reading metadata from dataset with reader 'abi_netcdf'...
27_144454 single_source.py:1498 INTERACTIVE: Reading sectored dataset for self registered products with reader 'abi_netcdf'...
/home/evrose54/anaconda3/envs/geoips/lib/python3.10/site-packages/pyproj/crs/crs.py:1293: UserWarning: You will likely lose important projection information when converting to a PROJ string from another format. See: https://proj.org/faq.html#what-is-the-best-format-for-describing-coordinate-reference-systems
  proj = self._crs.to_proj4(version=version)
27_144456   abi_netcdf.py:778  INTERACTIVE: Done with geolocation for goes16
27_144457 single_source.py:1530 INTERACTIVE: Sectoring xarrays...
27_144457 single_source.py:1569 INTERACTIVE: Producing sectored outputs...
27_144457 single_source.py:881  INTERACTIVE: Applying algorithms and interpolation...
27_144457 single_source.py:907  INTERACTIVE: Resectoring xarrays without padding...
27_144457 single_source.py:1150 INTERACTIVE:   Interpolating data with interpolator 'interp_gauss_test'...
27_144501 single_source.py:1208 INTERACTIVE:   Applying 'list_numpy_to_numpy' family algorithm 'single_channel' to data...
27_144501 single_source.py:506  INTERACTIVE: Producing product 'Infrared-Test' final outputs as type 'imagery_test'...
/home/evrose54/geoips/geoips_packages/outdirs/preprocessed/annotated_imagery
27_144501 single_source.py:548  INTERACTIVE:   Producing 'image' family final outputs 'imagery_test'...
27_144502 single_source.py:1836 INTERACTIVE: 


Processing complete! Checking outputs...


27_144509 single_source.py:1869 INTERACTIVE: 


The following products were produced from procflow single_source.py


27_144509 single_source.py:1874 INTERACTIVE:     SINGLESOURCESUCCESS ${GEOIPS_OUTDIRS}/preprocessed/annotated_imagery/Global-x-GOES-16/x-x-x/Infrared-Test/abi/20200918.195020.goes-16.abi.Infrared-Test.goes16.45p56.noaa.10p0.png
27_144509 single_source.py:1884 INTERACTIVE: READER_NAME: abi_netcdf
27_144509 single_source.py:1885 INTERACTIVE: PRODUCT_NAME: Infrared-Test
27_144509 single_source.py:1886 INTERACTIVE: NUM_PRODUCTS: 1
27_144509 single_source.py:1887 INTERACTIVE: NUM_DELETED_PRODUCTS: 0
27_144509 run_procflow.py:70   INTERACTIVE: Completed geoips PROCFLOW single_source processing, done!
27_144509 run_procflow.py:76   INTERACTIVE: Total time: 0:00:14.989090
27_144509 run_procflow.py:96   INTERACTIVE: Return value: 0
